### PR TITLE
Fix ts type for semicolons to be array

### DIFF
--- a/lib/ast.d.ts
+++ b/lib/ast.d.ts
@@ -55,7 +55,7 @@ interface Bracketed {
     close: Punctuation;
 }
 interface Terminated {
-    semi?: Punctuation;
+    semi?: Punctuation[];
 }
 interface Op {
     operator: Punctuation;

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -62,7 +62,7 @@ interface Bracketed {
 
 interface Terminated {
   // Semicolons are always optional.
-  semi?: Punctuation;
+  semi?: Punctuation[];
 }
 
 interface Op {


### PR DESCRIPTION
Found when fitting in to eslint-plugin.